### PR TITLE
Add example for server_command for sftp

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -710,6 +710,17 @@ Properties:
 - Type:        string
 - Required:    false
 
+If adding `server_command` to the configuration file please note that 
+it should not be enclosed in quotes, since that will make rclone fail.
+
+A working example is:
+```` 
+[remote_name]
+type = sftp
+server_command = sudo /usr/libexec/openssh/sftp-server
+````
+
+
 #### --sftp-use-fstat
 
 If set use fstat instead of stat.


### PR DESCRIPTION
More documentation that explicitly states that server_command should not be enclosed on quotes

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Help people understand exactly how server_command should be used
#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
https://forum.rclone.org/t/sftp-server-command-help/41412
#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
